### PR TITLE
Fix(package.json): correct license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "arc"
   ],
   "author": "Henry Thasler",
-  "license": "ISC",
+  "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/henrythasler/Leaflet.Geodesic/issues"
   },


### PR DESCRIPTION
This PR addresses issue #26

The previous value in `package.json` probably comes from the default value `"ISC"` (permissive license), whereas author meant `"GPL-3.0"`, as stated in README, LICENSE and main file header.

`"GPL-3.0"` is the valid SPDX identifier for GPL v3 license: https://spdx.org/licenses/GPL-3.0.html

Fix #26