### PR TITLE
Improved no-wrapping; unify dash/non-dash code

### DIFF
--- a/Leaflet.Geodesic.js
+++ b/Leaflet.Geodesic.js
@@ -18,7 +18,6 @@
 // along with Leaflet.Geodesic.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
 /** Extend Number object with method to convert numeric degrees to radians */
 if (typeof Number.prototype.toRadians === "undefined") {
   Number.prototype.toRadians = function() {
@@ -45,20 +44,19 @@ L.Geodesic = L.Polyline.extend({
 
   initialize: function(latlngs, options) {
     this.options = this._merge_options(this.options, options);
+    this.options.dash = Math.max(1e-3, Math.min(1, parseFloat(this.options.dash) || 1));
     this.datum = {};
     this.datum.ellipsoid = {
         a: 6378137,
         b: 6356752.3142,
         f: 1 / 298.257223563
       }; // WGS-84
-    this._latlngs = (this.options.dash < 1) ? this._generate_GeodesicDashed(
-      latlngs) : this._generate_Geodesic(latlngs);
+    this._latlngs = this._generate_Geodesic(latlngs);
     L.Polyline.prototype.initialize.call(this, this._latlngs, this.options);
   },
 
   setLatLngs: function(latlngs) {
-    this._latlngs = (this.options.dash < 1) ? this._generate_GeodesicDashed(
-      latlngs) : this._generate_Geodesic(latlngs);
+    this._latlngs = this._generate_Geodesic(latlngs);
     L.Polyline.prototype.setLatLngs.call(this, this._latlngs);
   },
 
@@ -179,31 +177,41 @@ L.Geodesic = L.Polyline.extend({
 
   /**
    * Creates a geodesic Polyline from given coordinates
+   * Note: dashed lines are under work
    * @param {Object} latlngs - One or more polylines as an array. See Leaflet doc about Polyline
    * @returns (Object} An array of arrays of geographical points.
    */
   _generate_Geodesic: function(latlngs) {
     let _geo = [],
       _geocnt = 0,
+      continuous_offset = 0,
       s, poly, points, pointA, pointB;
 
     for (poly = 0; poly < latlngs.length; poly++) {
       _geo[_geocnt] = [];
       for (points = 0; points < (latlngs[poly].length - 1); points++) {
-        pointA = L.latLng(latlngs[poly][points]);
-        pointB = L.latLng(latlngs[poly][points + 1]);
+        // continuous_offset keeps track of points beyond +/-180, so we can safely wrap
+        pointA = L.latLng(latlngs[poly][points]).wrap();
+        pointB = L.latLng(latlngs[poly][points + 1]).wrap();
         if (pointA.equals(pointB)) {
           continue;
         }
+        if (continuous_offset){
+          pointA.lng += continuous_offset;
+          pointB.lng += continuous_offset;
+        }
         let inverse = this._vincenty_inverse(pointA, pointB);
         let prev = pointA;
+        let first_lng = prev.lng;
         _geo[_geocnt].push(prev);
         for (s = 1; s <= this.options.steps;) {
-          let direct = this._vincenty_direct(pointA, inverse.initialBearing,
-            inverse.distance / this.options.steps * s, this.options.wrap
-          );
+          let distance = inverse.distance / this.options.steps;
+          // dashed lines don't go the full distance between the points
+		  let dist_mult = s - 1 + this.options.dash;
+          let direct = this._vincenty_direct(pointA, inverse.initialBearing, distance*dist_mult, this.options.wrap);
           let gp = L.latLng(direct.lat, direct.lng);
           if (Math.abs(gp.lng - prev.lng) > 180) {
+			  console.log("180");
             let sec = this._intersection(pointA, inverse.initialBearing, {
               lat: -89,
               lng: ((gp.lng - prev.lng) > 0) ? -INTERSECT_LNG : INTERSECT_LNG
@@ -220,83 +228,36 @@ L.Geodesic = L.Polyline.extend({
               _geo[_geocnt].push(gp);
               prev = gp;
               s++;
-            }
+            }  
           } else {
             _geo[_geocnt].push(gp);
-            prev = gp;
+            // Dashed lines start a new line
+            if (this.options.dash < 1){
+				_geocnt++;
+				// go full distance this time, to get starting point for next line
+				let direct_full = this._vincenty_direct(pointA, inverse.initialBearing, distance*s, this.options.wrap);
+				_geo[_geocnt] = [];
+				prev = L.latLng(direct_full.lat, direct_full.lng);
+				_geo[_geocnt].push(prev);
+			}
+            else prev = gp;
             s++;
           }
+        }
+        // If geodesic line crosses the -180/180 boundary, increment continuous_offset
+        if (!this.options.wrap){
+		  let last_lng = prev.lng;
+          // check the multiple of 360 that thie first/last lie in
+          let mult_first = Math.floor((first_lng+180)/360);
+          let mult_last = Math.floor((last_lng+180)/360);
+          // if they are different, we crossed a boundary; add offset +/-360
+          continuous_offset += 360*(mult_last-mult_first);
         }
       }
       _geocnt++;
     }
     return _geo;
   },
-
-
-  /**
-   * Creates a dashed geodesic Polyline from given coordinates - under work
-   * @param {Object} latlngs - One or more polylines as an array. See Leaflet doc about Polyline
-   * @returns (Object} An array of arrays of geographical points.
-   */
-  _generate_GeodesicDashed: function(latlngs) {
-    let _geo = [],
-      _geocnt = 0,
-      s, poly, points;
-      //      _geo = latlngs;    // bypass
-
-    for (poly = 0; poly < latlngs.length; poly++) {
-      _geo[_geocnt] = [];
-      for (points = 0; points < (latlngs[poly].length - 1); points++) {
-        let inverse = this._vincenty_inverse(L.latLng(latlngs[poly][
-          points
-        ]), L.latLng(latlngs[poly][points + 1]));
-        let prev = L.latLng(latlngs[poly][points]);
-        _geo[_geocnt].push(prev);
-        for (s = 1; s <= this.options.steps;) {
-          let direct = this._vincenty_direct(L.latLng(latlngs[poly][
-              points
-            ]), inverse.initialBearing, inverse.distance / this.options
-            .steps * s - inverse.distance / this.options.steps * (1 -
-              this.options.dash), this.options.wrap);
-          let gp = L.latLng(direct.lat, direct.lng);
-          if (Math.abs(gp.lng - prev.lng) > 180) {
-            let sec = this._intersection(L.latLng(latlngs[poly][points]),
-              inverse.initialBearing, {
-                lat: -89,
-                lng: ((gp.lng - prev.lng) > 0) ? -INTERSECT_LNG : INTERSECT_LNG
-              }, 0);
-            if (sec) {
-              _geo[_geocnt].push(L.latLng(sec.lat, sec.lng));
-              _geocnt++;
-              _geo[_geocnt] = [];
-              prev = L.latLng(sec.lat, -sec.lng);
-              _geo[_geocnt].push(prev);
-            } else {
-              _geocnt++;
-              _geo[_geocnt] = [];
-              _geo[_geocnt].push(gp);
-              prev = gp;
-              s++;
-            }
-          } else {
-            _geo[_geocnt].push(gp);
-            _geocnt++;
-            let direct2 = this._vincenty_direct(L.latLng(latlngs[poly][
-                points
-              ]), inverse.initialBearing, inverse.distance / this.options
-              .steps * s, this.options.wrap);
-            _geo[_geocnt] = [];
-            _geo[_geocnt].push(L.latLng(direct2.lat, direct2.lng));
-            s++;
-          }
-        }
-      }
-      _geocnt++;
-    }
-    return _geo;
-  },
-
 
   /**
    * Vincenty direct calculation.

--- a/Leaflet.Geodesic.js
+++ b/Leaflet.Geodesic.js
@@ -182,24 +182,21 @@ L.Geodesic = L.Polyline.extend({
    * @returns (Object} An array of arrays of geographical points.
    */
   _generate_Geodesic: function(latlngs) {
-    let _geo = [],
-      _geocnt = 0,
-      s, poly, points, pointA, pointB;
+    let _geo = [], _geocnt = 0;
 
-    for (poly = 0; poly < latlngs.length; poly++) {
+    for (let poly = 0; poly < latlngs.length; poly++) {
       _geo[_geocnt] = [];
-      let prev = null;
-      for (points = 0; points < (latlngs[poly].length - 1); points++) {
+      let prev = L.latLng(latlngs[poly][0]);
+      for (let points = 0; points < (latlngs[poly].length - 1); points++) {
         // use prev, so that wrapping behaves correctly
-        pointA = prev || L.latLng(latlngs[poly][points]);
-        pointB = L.latLng(latlngs[poly][points + 1]);
+        let pointA = prev;
+        let pointB = L.latLng(latlngs[poly][points + 1]);
         if (pointA.equals(pointB)) {
           continue;
         }
         let inverse = this._vincenty_inverse(pointA, pointB);
-        prev = pointA;
         _geo[_geocnt].push(prev);
-        for (s = 1; s <= this.options.steps;) {
+        for (let s = 1; s <= this.options.steps;) {
           let distance = inverse.distance / this.options.steps;
           // dashed lines don't go the full distance between the points
           let dist_mult = s - 1 + this.options.dash;

--- a/Leaflet.Geodesic.js
+++ b/Leaflet.Geodesic.js
@@ -241,7 +241,6 @@ L.Geodesic = L.Polyline.extend({
       }
       _geocnt++;
     }
-    console.log("done");
     return _geo;
   },
 

--- a/example/continuousNoWrap.html
+++ b/example/continuousNoWrap.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+ <head>
+	<title>Leaflet.Geodesic Example - by Henry Thasler</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+	<style type="text/css">
+		    body {
+			    padding: 0;
+			    margin: 0;
+		    }
+		    html, body, #map {
+			    height: 100%;
+		    }
+		    .info {
+			padding: 6px 8px;
+			font: 14px/16px Arial, Helvetica, sans-serif;
+			background: white;
+			background: rgba(255,255,255,0.8);
+			box-shadow: 0 0 15px rgba(0,0,0,0.2);
+			border-radius: 5px;
+		    }
+		    .info h4 {
+			padding-right: 5px;
+			margin: 0 0 5px;
+		    }
+	</style>
+	<script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script>
+	<script src="../Leaflet.Geodesic.js"></script>
+ </head>
+ <body>
+	<div id="map"></div>
+	<script>
+		var map = L.map('map').setView([30, 180], 2);
+        L.tileLayer('https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			maxZoom: 15,
+			noWrap: false,
+			attribution: 'Map tiles by Carto, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
+		}).addTo(map);
+    
+    var markers = [];
+    
+    function update(){
+      Geodesic.setLatLngs([markers.map(x => x.getLatLng())]);
+    }
+    
+    var INTERACTIVE = false;
+    for (var i=0; i<10; i++){
+      var lat = Math.sin(i*Math.PI*.25)*15+30;
+      var lng = 50*i;
+      var m = L.marker(new L.LatLng(lat, lng).wrap(), {draggable: true});
+      if (INTERACTIVE)
+        m.addTo(map).on("drag", update);
+      markers.push(m);
+    }
+    markers[3].setLatLng(new L.LatLng(37, 180));
+		
+		var Geodesic = L.geodesic([[]], {
+			weight: 7,
+			opacity: 0.5,
+      steps:10,
+      dash:.4,
+			color: 'blue',
+			wrap: false
+		}).addTo(map);
+    
+    update();
+    
+	</script>
+ </body>
+</html>


### PR DESCRIPTION
The first change is to improve the no-wrapping behavior for line strings. I've added an example `continuousNoWrap.html`, which demonstrates it. Previously, this line string which crosses +180 would still wrap; now it doesn't.

The second change is to merge the dash and non-dash code. The differences are slight, so I figured it would be better to keep a single method; that way we don't have to copy code changes between the two methods.