### PR TITLE
base-class from Layer to Polyline

### DIFF
--- a/docs/testing-circle.html
+++ b/docs/testing-circle.html
@@ -77,9 +77,10 @@
             color: 'red',
             fill: true,
             steps: 80
-        }).addTo(map);
+        }).bindTooltip("<Area>").bindPopup("GeodesicCircle").addTo(map);
 
         geodesiccircle.setRadius(geodesiccircle.distanceTo(B.getLatLng()));
+        geodesiccircle.setTooltipContent(`Area: ${Math.round(geodesiccircle.radius**2*Math.PI/1000**2)} km²`);
 
         var info = L.control();
         info.onAdd = function (map) {
@@ -113,11 +114,13 @@
             geodesiccircle.setLatLng(e.latlng);
             geodesiccircle.setRadius(geodesiccircle.distanceTo(B.getLatLng()));
             info.update(geodesiccircle.statistics);
+            geodesiccircle.setTooltipContent(`Area: ${Math.round(geodesiccircle.radius**2*Math.PI/1000**2)} km²`);
         });
         B.on('drag', (e) => {
             B.setTooltipContent(`${Math.round(10000 * e.latlng.lat) / 10000} ${Math.round(10000 * e.latlng.lng) / 10000}`);
             geodesiccircle.setRadius(geodesiccircle.distanceTo(e.latlng));
             info.update(geodesiccircle.statistics);
+            geodesiccircle.setTooltipContent(`Area: ${Math.round(geodesiccircle.radius**2*Math.PI/1000**2)} km²`);
         });
 
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,8 +1410,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
-      "dev": true
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
     },
     "commondir": {
       "version": "1.0.1",
@@ -3089,10 +3088,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha1-Gx+U+b/nN5rdqGqLc/tXAmWg3d0=",
-      "dev": true,
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -3103,8 +3101,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -4651,8 +4648,7 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
-      "dev": true
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4890,7 +4886,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -4899,8 +4894,7 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
     },
@@ -6958,10 +6952,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
-      "integrity": "sha1-iMyIDG7Vz5ho/foHYGVOe+1GPx0=",
-      "dev": true,
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "optional": true,
       "requires": {
         "commander": "~2.20.3",
@@ -6972,7 +6965,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -7191,8 +7183,7 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/spec/geodesic-circle.test.ts
+++ b/spec/geodesic-circle.test.ts
@@ -33,69 +33,65 @@ function checkFixture(specimen: L.LatLngLiteral[][], fixture: L.LatLngLiteral[][
     });
 }
 
+function compareObject(specimen: object, fixture: object): void {
+    for (let [key, value] of Object.entries(specimen)) {
+        expect(specimen).to.have.own.property(key, value);
+    }
+}
+
 describe("Main functionality", function () {
+    let container: HTMLElement;
     let map: L.Map;
     const radius = 1000 * 1000;
 
     beforeEach(function () {
-        map = L.map(document.createElement('div'));
-    });
-
-    afterEach(function () {
-        map.remove();
+        container = document.createElement('div');
+        container.style.width = '400px';
+        container.style.height = '400px';
+        map = L.map(container, { renderer: new L.SVG(), center: [0, 0], zoom: 12 });
     });
 
     it("Create class w/o any parameters", function () {
         const circle = new GeodesicCircleClass();
-        expect(circle.options).to.be.deep.equal(defaultOptions);
-        expect(circle.polyline).to.be.an("object");
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        compareObject(circle.options, defaultOptions);
     });
 
     it("Create class with parameters", function () {
         const circle = new GeodesicCircleClass(Beijing, { steps: 48 });
-        expect(circle.options).to.be.deep.equal({ ...defaultOptions, ...{ steps: 48 } });
-        expect(circle.polyline).to.be.an("object");
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        compareObject(circle.options, defaultOptions);
     });
 
     it("Add empty circle to map", async function () {
         const circle = new GeodesicCircleClass().addTo(map);
-        expect(circle.options).to.be.deep.equal(defaultOptions);
-        expect(circle.polyline).to.be.an("object");
-
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        compareObject(circle.options, defaultOptions);
         expect(map.hasLayer(circle)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicCircleClass);
-        });
     });
 
     it("update center", async function () {
         const circle = new GeodesicCircleClass(Seattle).addTo(map);
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        compareObject(circle.options, defaultOptions);
+        expect(map.hasLayer(circle)).to.be.true;
+
         circle.setLatLng(Beijing);
-        expect(circle.options).to.be.deep.equal(defaultOptions);
-        expect(circle.polyline).to.be.an("object");
         expect(circle.center.lat).to.be.closeTo(Beijing.lat, eps);
         expect(circle.center.lng).to.be.closeTo(Beijing.lng, eps);
         expect(circle.radius).to.be.closeTo(radius, eps);
-
-        expect(map.hasLayer(circle)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicCircleClass);
-        });
     });
 
     it("update radius", async function () {
         const circle = new GeodesicCircleClass(Seattle, { radius: radius }).addTo(map);
-        expect(circle.options).to.be.deep.equal({ ...defaultOptions, ...{ radius: radius } });
-        expect(circle.polyline).to.be.an("object");
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        compareObject(circle.options, { ...defaultOptions, ...{ radius: radius } });
+        expect(map.hasLayer(circle)).to.be.true;
+
         expect(circle.center.lat).to.be.closeTo(Seattle.lat, eps);
         expect(circle.center.lng).to.be.closeTo(Seattle.lng, eps);
         circle.setRadius(2 * radius);
         expect(circle.radius).to.be.closeTo(2 * radius, eps);
-
-        expect(map.hasLayer(circle)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicCircleClass);
-        });
     });
 
     it("distance function (wrapper for vincenty inverse)", function () {
@@ -117,30 +113,26 @@ describe("Main functionality", function () {
 });
 
 describe("Bugs", function () {
+    let container: HTMLElement;
     let map: L.Map;
 
     beforeEach(function () {
-        map = L.map(document.createElement('div'));
-    });
-
-    afterEach(function () {
-        map.remove();
+        container = document.createElement('div');
+        container.style.width = '400px';
+        container.style.height = '400px';
+        map = L.map(container, { renderer: new L.SVG(), center: [0, 0], zoom: 12 });
     });
 
     it("Calling getBounds on a GeodesicCircle throws an error (#48)", async function () {
         const circle = new GeodesicCircleClass(Seattle, { radius: 10});
         const group = new L.FeatureGroup([circle]).addTo(map);
 
-        expect(circle.options).to.be.deep.equal({ ...defaultOptions, ...{ radius: 10 } });
-        expect(circle.polyline).to.be.an("object");
+        compareObject(circle.options, { ...defaultOptions, ...{ radius: 10 } });
         expect(circle.center.lat).to.be.closeTo(Seattle.lat, eps);
         expect(circle.center.lng).to.be.closeTo(Seattle.lng, eps);
 
         expect(map.hasLayer(group)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(L.FeatureGroup);
-        });
-
+        
         const bounds = group.getBounds();
         expect(bounds).to.be.instanceOf(L.LatLngBounds);
         checkFixture([[bounds.getCenter()]], [[Seattle]]);

--- a/spec/geodesic-circle.test.ts
+++ b/spec/geodesic-circle.test.ts
@@ -53,26 +53,26 @@ describe("Main functionality", function () {
 
     it("Create class w/o any parameters", function () {
         const circle = new GeodesicCircleClass();
-        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);
         compareObject(circle.options, defaultOptions);
     });
 
     it("Create class with parameters", function () {
         const circle = new GeodesicCircleClass(Beijing, { steps: 48 });
-        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);
         compareObject(circle.options, defaultOptions);
     });
 
     it("Add empty circle to map", async function () {
         const circle = new GeodesicCircleClass().addTo(map);
-        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);
         compareObject(circle.options, defaultOptions);
         expect(map.hasLayer(circle)).to.be.true;
     });
 
     it("update center", async function () {
         const circle = new GeodesicCircleClass(Seattle).addTo(map);
-        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);
         compareObject(circle.options, defaultOptions);
         expect(map.hasLayer(circle)).to.be.true;
 
@@ -84,7 +84,7 @@ describe("Main functionality", function () {
 
     it("update radius", async function () {
         const circle = new GeodesicCircleClass(Seattle, { radius: radius }).addTo(map);
-        expect(circle).to.be.instanceOf(GeodesicCircleClass);        
+        expect(circle).to.be.instanceOf(GeodesicCircleClass);
         compareObject(circle.options, { ...defaultOptions, ...{ radius: radius } });
         expect(map.hasLayer(circle)).to.be.true;
 
@@ -124,7 +124,7 @@ describe("Bugs", function () {
     });
 
     it("Calling getBounds on a GeodesicCircle throws an error (#48)", async function () {
-        const circle = new GeodesicCircleClass(Seattle, { radius: 10});
+        const circle = new GeodesicCircleClass(Seattle, { radius: 10 });
         const group = new L.FeatureGroup([circle]).addTo(map);
 
         compareObject(circle.options, { ...defaultOptions, ...{ radius: 10 } });
@@ -132,7 +132,7 @@ describe("Bugs", function () {
         expect(circle.center.lng).to.be.closeTo(Seattle.lng, eps);
 
         expect(map.hasLayer(group)).to.be.true;
-        
+
         const bounds = group.getBounds();
         expect(bounds).to.be.instanceOf(L.LatLngBounds);
         checkFixture([[bounds.getCenter()]], [[Seattle]]);

--- a/spec/geodesic-geom.test.ts
+++ b/spec/geodesic-geom.test.ts
@@ -68,6 +68,14 @@ function checkFixture(specimen: L.LatLngLiteral[][], fixture: L.LatLngLiteral[][
     });
 }
 
+describe("constructor and properties", function () {
+    it("no additional settings given", function () {
+        expect(geom.steps).to.be.equal(3);
+        expect(geom.options.steps).to.be.equal(3);
+        expect(geom.options.wrap).to.be.true;
+    });
+});
+
 describe("recursiveMidpoint method", function () {
     it("Seatle to Capetown, zero iterations (just the midpoint)", function () {
         const n = 0;
@@ -326,5 +334,5 @@ describe("multilineDistance()", function () {
         expect(res).to.be.length(1);
         const sum = res.reduce((x, y) => x + y, 0);
         expect(sum).to.be.closeTo(0, eps);
-    });    
+    });
 });

--- a/spec/geodesic-line.test.ts
+++ b/spec/geodesic-line.test.ts
@@ -39,87 +39,82 @@ function checkFixture(specimen: L.LatLngLiteral[][], fixture: L.LatLngLiteral[][
     });
 }
 
+function compareObject(specimen: object, fixture: object): void {
+    for (let [key, value] of Object.entries(specimen)) {
+        expect(specimen).to.have.own.property(key, value);
+    }
+}
+
 describe("Main functionality", function () {
+    let container: HTMLElement;
     let map: L.Map;
 
     beforeEach(function () {
-        map = L.map(document.createElement('div'));
-    });
-
-    afterEach(function () {
-        map.remove();
+        container = document.createElement('div');
+        container.style.width = '400px';
+        container.style.height = '400px';
+        map = L.map(container, { renderer: new L.SVG(), center: [0, 0], zoom: 12 });
     });
 
     it("Create class w/o any parameters", function () {
         const line = new GeodesicLine();
-        expect(line.options).to.be.deep.equal(defaultOptions);
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, defaultOptions);
     });
 
     it("Create class with parameters", function () {
         const line = new GeodesicLine([], { steps: 0 });
-        expect(line.options).to.be.deep.equal({ ...defaultOptions, ...{ steps: 0 } });
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, { ...defaultOptions, ...{ steps: 0 } });
     });
 
     it("Create class with parameters", function () {
         const line = new GeodesicLine([], { wrap: false });
-        expect(line.options).to.be.deep.equal({ ...defaultOptions, ...{ wrap: false } });
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, { ...defaultOptions, ...{ wrap: false } });
     });
 
-    it("Add empty line to map", async function () {
+    it("Add empty line to map", function () {
         const line = new GeodesicLine().addTo(map);
-        expect(line.options).to.be.deep.equal(defaultOptions);
-        expect(line.polyline).to.be.an("object");
-
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, defaultOptions);
         expect(map.hasLayer(line)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicLine);
-        });
     });
 
-    it("Modify Line", async function () {
+    it("Modify Line", function () {
         const line = new GeodesicLine().addTo(map);
-        expect(line.options).to.be.deep.equal(defaultOptions);
-        expect(line.polyline).to.be.an("object");
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, defaultOptions);
         expect(map.hasLayer(line)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicLine);
-        });
         line.setLatLngs([Berlin, Capetown]);
     });
 
-    it("Modify Line w/o wrapping", async function () {
+    it("Modify Line w/o wrapping", function () {
         const line = new GeodesicLine([], { wrap: false }).addTo(map);
-        expect(line.options).to.be.deep.equal({ ...defaultOptions, ...{ wrap: false } });
-        expect(line.polyline).to.be.an("object");
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, { ...defaultOptions, ...{ wrap: false } });
         expect(map.hasLayer(line)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicLine);
-        });
         line.setLatLngs([Berlin, Capetown]);
     });
 
-    it("Read LatLngs", async function () {
+    it("Read LatLngs from empty line", function () {
         const line = new GeodesicLine().addTo(map);
-        expect(line.options).to.be.deep.equal(defaultOptions);
-        expect(line.polyline).to.be.an("object");
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, defaultOptions);
         expect(map.hasLayer(line)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicLine);
-        });
         const latlngs = line.getLatLngs();
         expect(latlngs).to.be.an("array");
+        expect(latlngs.length).to.be.equal(0);
     });
 
-    it("Read LatLngs", async function () {
-        const line = new GeodesicLine().addTo(map);
-        expect(line.options).to.be.deep.equal(defaultOptions);
-        expect(line.polyline).to.be.an("object");
+    it("Read LatLngs", function () {
+        const line = new GeodesicLine([Berlin, Capetown]).addTo(map);
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, defaultOptions);
         expect(map.hasLayer(line)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(GeodesicLine);
-        });
         const latlngs = line.getLatLngs();
         expect(latlngs).to.be.an("array");
+        expect(latlngs.length).to.be.equal(1);
     });
 
     it("Statistics calculation (simple)", async function () {
@@ -144,22 +139,27 @@ describe("Main functionality", function () {
         const line = new GeodesicLine();
         const distance = line.distance(FlindersPeak, Buninyong);
         expect(distance).to.be.closeTo(54972.271, 0.001);
-    });    
+    });
 });
 
 describe("GeoJSON-Support", function () {
+    let container: HTMLElement;
     let map: L.Map;
     const mockLog = jest.fn();
-    console.log = mockLog;
+    const originalLog = console.log;
 
     beforeEach(function () {
-        map = L.map(document.createElement('div'));
+        container = document.createElement('div');
+        container.style.width = '400px';
+        container.style.height = '400px';
+        map = L.map(container, { renderer: new L.SVG(), center: [0, 0], zoom: 12 });
+
         mockLog.mockClear();
     });
 
     afterEach(function () {
-        map.remove();
-    });
+        console.log = originalLog;
+    })
 
     it("Just a Linestring", async function () {
         const line = new GeodesicLine([], { steps: 0 }).addTo(map);
@@ -237,6 +237,8 @@ describe("GeoJSON-Support", function () {
     });
 
     it("FeatureCollection with Point", async function () {
+        console.log = mockLog;
+
         const line = new GeodesicLine([], { steps: 0 }).addTo(map);
         const geojson: GeoJSON.GeoJSON = JSON.parse(readFileSync(`${fixturesPath}point.geojson`, "utf8"));
         line.fromGeoJson(geojson);
@@ -247,6 +249,8 @@ describe("GeoJSON-Support", function () {
     });
 
     it("Mixed FeatureCollection", async function () {
+        console.log = mockLog;
+
         const line = new GeodesicLine([], { steps: 0 }).addTo(map);
         const geojson: GeoJSON.GeoJSON = JSON.parse(readFileSync(`${fixturesPath}mixed.geojson`, "utf8"));
         line.fromGeoJson(geojson);
@@ -256,6 +260,8 @@ describe("GeoJSON-Support", function () {
     });
 
     it("GeometryCollection", async function () {
+        console.log = mockLog;
+
         const line = new GeodesicLine([], { steps: 0 }).addTo(map);
         const geojson: GeoJSON.GeoJSON = JSON.parse(readFileSync(`${fixturesPath}geometrycollection.geojson`, "utf8"));
         line.fromGeoJson(geojson);
@@ -266,31 +272,38 @@ describe("GeoJSON-Support", function () {
     });
 });
 
-describe("Re-Implementing Layer-Functions", function () {
+describe("Usage of base-class functions", function () {
+    let container: HTMLElement;
     let map: L.Map;
 
     beforeEach(function () {
-        map = L.map(document.createElement('div'));
-    });
-
-    afterEach(function () {
-        map.remove();
+        container = document.createElement('div');
+        container.style.width = '400px';
+        container.style.height = '400px';
+        map = L.map(container, { renderer: new L.SVG(), center: [0, 0], zoom: 12 });
     });
 
     it("getBounds()", async function () {
+        const line = new GeodesicLine([FlindersPeak, Buninyong]).addTo(map);
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, defaultOptions);
+        expect(map.hasLayer(line)).to.be.true;
+
+        const bounds = line.getBounds();
+        expect(bounds).to.be.instanceOf(L.LatLngBounds);
+        checkFixture([[bounds.getCenter()]], [[{ lat: (FlindersPeak.lat + Buninyong.lat) / 2, lng: (FlindersPeak.lng + Buninyong.lng) / 2 }]]);
+    });
+
+    it("getBounds() in FeatureGroup", async function () {
         const line = new GeodesicLine([FlindersPeak, Buninyong]);
+        expect(line).to.be.instanceOf(GeodesicLine);
+        compareObject(line.options, defaultOptions);
+
         const group = new L.FeatureGroup([line]).addTo(map);
-
-        expect(line.options).to.be.deep.equal(defaultOptions);
-        expect(line.polyline).to.be.an("object");
-
         expect(map.hasLayer(group)).to.be.true;
-        map.eachLayer(function (layer) {
-            expect(layer).to.be.instanceOf(L.FeatureGroup);
-        });
 
         const bounds = group.getBounds();
         expect(bounds).to.be.instanceOf(L.LatLngBounds);
-        checkFixture([[bounds.getCenter()]], [[{lat: (FlindersPeak.lat+Buninyong.lat)/2, lng: (FlindersPeak.lng+Buninyong.lng)/2}]]);
+        checkFixture([[bounds.getCenter()]], [[{ lat: (FlindersPeak.lat + Buninyong.lat) / 2, lng: (FlindersPeak.lng + Buninyong.lng) / 2 }]]);
     });
 });

--- a/src/geodesic-circle.ts
+++ b/src/geodesic-circle.ts
@@ -3,32 +3,34 @@ import { GeodesicGeometry, Statistics } from "./geodesic-geom"
 import { GeodesicOptions } from "./geodesic-core"
 import { latlngExpressiontoLiteral } from "./types-helper";
 
+/**
+ * Can be used to create a geodesic circle based on L.Polyline
+ */
 export class GeodesicCircleClass extends L.Polyline {
     defaultOptions: GeodesicOptions = { wrap: true, steps: 24, fill: true, noClip: true};
-    private geom: GeodesicGeometry;
-    center: L.LatLngLiteral = { lat: 0, lng: 0 };
-    radius: number = 1000 * 1000;
+    readonly geom: GeodesicGeometry;
+    center: L.LatLngLiteral;
+    radius: number;
     statistics: Statistics = {} as any;
 
     constructor(center?: L.LatLngExpression, options?: GeodesicOptions) {
         super([], options);
         L.Util.setOptions(this, {...this.defaultOptions, ...options});
 
+        // merge/set options
         const extendedOptions = this.options as GeodesicOptions;
         this.radius = (extendedOptions.radius === undefined) ? 1000 * 1000 : extendedOptions.radius;
+        this.center = (center === undefined) ? { lat: 0, lng: 0 }: latlngExpressiontoLiteral(center);
 
         this.geom = new GeodesicGeometry(this.options);
 
-        if (center) {
-            this.center = latlngExpressiontoLiteral(center);
-            let latlngs = this.geom.circle(this.center, this.radius);
-            this.statistics = this.geom.updateStatistics([[this.center]], [latlngs]);
-            // circumfence must be re-calculated from geodesic 
-            this.statistics.totalDistance = this.geom.multilineDistance([latlngs]).reduce((x, y) => x + y, 0);
-            this.setLatLngs(latlngs);
-        }
+        // update the geometry
+        this.update();
     }
 
+    /**
+     * Updates the geometry and re-calculates some statistics
+     */
     private update(): void {
         const latlngs = this.geom.circle(this.center, this.radius);
 
@@ -39,16 +41,29 @@ export class GeodesicCircleClass extends L.Polyline {
         this.setLatLngs(latlngs);
     }
 
+    /**
+     * Calculate the distance between the current center and an arbitrary position.
+     * @param latlng geo-position to calculate distance to
+     * @return distance in meters
+     */
     distanceTo(latlng: L.LatLngExpression): number {
         const dest = latlngExpressiontoLiteral(latlng);
         return this.geom.distance(this.center, dest);
     }
 
+    /**
+     * Set a new center for the geodesic circle and update the geometry.
+     * @param latlng new geo-position for the center
+     */
     setLatLng(latlng: L.LatLngExpression): void {
         this.center = latlngExpressiontoLiteral(latlng);
         this.update();
     }
 
+    /**
+     * set a new radius for the geodesic circle and update the geometry
+     * @param radius new radius in meters
+     */
     setRadius(radius: number): void {
         this.radius = radius;
         this.update();

--- a/src/geodesic-circle.ts
+++ b/src/geodesic-circle.ts
@@ -7,7 +7,7 @@ import { latlngExpressiontoLiteral } from "./types-helper";
  * Can be used to create a geodesic circle based on L.Polyline
  */
 export class GeodesicCircleClass extends L.Polyline {
-    defaultOptions: GeodesicOptions = { wrap: true, steps: 24, fill: true, noClip: true};
+    defaultOptions: GeodesicOptions = { wrap: true, steps: 24, fill: true, noClip: true };
     readonly geom: GeodesicGeometry;
     center: L.LatLngLiteral;
     radius: number;
@@ -15,12 +15,12 @@ export class GeodesicCircleClass extends L.Polyline {
 
     constructor(center?: L.LatLngExpression, options?: GeodesicOptions) {
         super([], options);
-        L.Util.setOptions(this, {...this.defaultOptions, ...options});
+        L.Util.setOptions(this, { ...this.defaultOptions, ...options });
 
         // merge/set options
         const extendedOptions = this.options as GeodesicOptions;
         this.radius = (extendedOptions.radius === undefined) ? 1000 * 1000 : extendedOptions.radius;
-        this.center = (center === undefined) ? { lat: 0, lng: 0 }: latlngExpressiontoLiteral(center);
+        this.center = (center === undefined) ? { lat: 0, lng: 0 } : latlngExpressiontoLiteral(center);
 
         this.geom = new GeodesicGeometry(this.options);
 

--- a/src/geodesic-geom.ts
+++ b/src/geodesic-geom.ts
@@ -11,9 +11,11 @@ export interface Statistics {
 export class GeodesicGeometry {
     readonly geodesic = new GeodesicCore();
     readonly options: GeodesicOptions = { wrap: true, steps: 3 };
+    steps: number;
 
     constructor(options?: GeodesicOptions) {
         this.options = { ...this.options, ...options };
+        this.steps = (this.options.steps === undefined) ? 3 : this.options.steps;
     }
 
     recursiveMidpoint(start: L.LatLngLiteral, dest: L.LatLngLiteral, iterations: number): L.LatLngLiteral[] {
@@ -34,14 +36,13 @@ export class GeodesicGeometry {
     }
 
     line(start: L.LatLngLiteral, dest: L.LatLngLiteral): L.LatLngLiteral[] {
-        return this.recursiveMidpoint(start, dest, Math.min(8, (this.options.steps === undefined) ? 3 : this.options.steps));
+        return this.recursiveMidpoint(start, dest, Math.min(8, this.steps));
     }
 
     circle(center: L.LatLngLiteral, radius: number): L.LatLngLiteral[] {
-        const steps = (this.options.steps === undefined) ? 24 : this.options.steps;
         const points: L.LatLngLiteral[] = [];
-        for (let i = 0; i < steps + 1; i++) {
-            const point: WGS84Vector = this.geodesic.direct(center, 360 / steps * i, radius);
+        for (let i = 0; i < this.steps + 1; i++) {
+            const point: WGS84Vector = this.geodesic.direct(center, 360 / this.steps * i, radius);
             points.push({ lat: point.lat, lng: point.lng } as L.LatLngLiteral);
         }
         return points;

--- a/src/geodesic-line.ts
+++ b/src/geodesic-line.ts
@@ -3,6 +3,9 @@ import { GeodesicOptions } from "./geodesic-core"
 import { GeodesicGeometry, Statistics } from "./geodesic-geom";
 import { latlngExpressiontoLiteral, latlngExpressionArraytoLiteralArray } from "../src/types-helper";
 
+/**
+ * Draw geodesic lines based on L.Polyline
+ */
 export class GeodesicLine extends L.Polyline {
     defaultOptions: GeodesicOptions = { wrap: true, steps: 3 };
     readonly geom: GeodesicGeometry;
@@ -15,11 +18,15 @@ export class GeodesicLine extends L.Polyline {
         this.geom = new GeodesicGeometry(this.options);
 
         if (latlngs !== undefined) {
-            this.update(latlngs);
+            this.setLatLngs(latlngs);
         }
     }
 
-    private update(latlngs: L.LatLngExpression[] | L.LatLngExpression[][]): void {
+    /**
+     * overwrites the original function with additional functionality to create a geodesic line
+     * @param latlngs an array (or 2d-array) of positions
+     */
+    setLatLngs(latlngs: L.LatLngExpression[] | L.LatLngExpression[][]): this {
         const latLngLiteral = latlngExpressionArraytoLiteralArray(latlngs);
         const geodesic = this.geom.multiLineString(latLngLiteral);
         this.statistics = this.geom.updateStatistics(latLngLiteral, geodesic);
@@ -30,13 +37,13 @@ export class GeodesicLine extends L.Polyline {
         else {
             super.setLatLngs(geodesic);
         }
-    }
-
-    setLatLngs(latlngs: L.LatLngExpression[] | L.LatLngExpression[][]): this {
-        this.update(latlngs);
         return this;
     }
 
+    /**
+     * Creates geodesic lines from a given GeoJSON-Object.
+     * @param input GeoJSON-Object
+     */
     fromGeoJson(input: GeoJSON.GeoJSON): this {
         let latlngs: L.LatLngExpression[][] = [];
         let features: GeoJSON.Feature[] = [];
@@ -79,11 +86,17 @@ export class GeodesicLine extends L.Polyline {
         });
 
         if (latlngs.length) {
-            this.update(latlngs);
+            this.setLatLngs(latlngs);
         }
         return this;
     }
 
+    /**
+     * Calculates the distance between two geo-positions
+     * @param start 1st position
+     * @param dest 2nd position
+     * @return the distance in meters
+     */
     distance(start: L.LatLngExpression, dest: L.LatLngExpression): number {
         return this.geom.distance(latlngExpressiontoLiteral(start), latlngExpressiontoLiteral(dest));
     }


### PR DESCRIPTION
Switch the base-class for all geodesic objects (line+circle) from L.Layer to L.Polyline. This avoids the need to re-implement functions as `getbounds()` or `bindTooltip()`. Geodesic lines and circles can be used as a drop-in replacement for a regular L.Polyline. This should make life easier in general for the user.