### PR TITLE
Export types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,13 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true,
+      "optional": true
+    },
     "@babel/helpers": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
@@ -6058,6 +6065,39 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-dts": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-1.4.8.tgz",
+      "integrity": "sha512-2qHB4B3oaTyi1mDmqDzsRGKlev32v3EhMUAmc45Cn9eB22R7FsYDiigvT9XdM/oQzfd0qv5MkeZju8DP0nauiA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        }
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
@@ -6996,9 +7036,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha1-sYdSuzeSvBoCgTNff26/G7/FuR0=",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/leaflet.geodesic.js",
   "module": "dist/leaflet.geodesic.esm.js",
   "browser": "dist/leaflet.geodesic.umd.min.js",
+  "types": "dist/leaflet.geodesic.d.ts",
   "files": [
     "dist"
   ],
@@ -48,6 +49,7 @@
     "postcss-assets": "^5.0.0",
     "rollup": "^1.26.3",
     "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-dts": "^1.4.8",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-postcss": "^2.0.3",
     "rollup-plugin-terser": "^5.1.2",
@@ -55,7 +57,7 @@
     "rollup-plugin-visualizer": "^2.6.1",
     "ts-jest": "^24.1.0",
     "typedoc": "^0.15.2",
-    "typescript": "^3.6.4"
+    "typescript": "^3.9.6"
   },
   "scripts": {
     "test": "jest \"^(?!.*benchmark).*$\" --coverage --",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import visualizer from 'rollup-plugin-visualizer';
 import { terser } from 'rollup-plugin-terser';
 import autoprefixer from 'autoprefixer';
 import assets from 'postcss-assets';
+import dts from 'rollup-plugin-dts';
 
 const banner = `/*! Leaflet.Geodesic ${pkg.version} - (c) Henry Thasler - https://github.com/henrythasler/Leaflet.Geodesic */`;
 
@@ -48,4 +49,15 @@ export default [
   bundle('esm', pkg.module),
   bundle('umd', pkg.browser.replace('.min', ''), { resolve: true, stats: true }),
   bundle('umd', pkg.browser, { resolve: true, minimize: true }),
+  {
+    input: 'src/index.ts',
+    output: {
+      file: pkg.types,
+      format: 'es',
+    },
+    plugins: [
+      dts(),
+      postcss({ inject: false }),
+    ],
+  },
 ];

--- a/spec/benchmark.test.ts
+++ b/spec/benchmark.test.ts
@@ -5,7 +5,7 @@ import Benchmark from "benchmark";
 import { GeodesicGeometry } from "../src/geodesic-geom";
 import { expect } from "chai";
 
-import L from "leaflet";
+import * as L from "leaflet";
 
 import "jest";
 

--- a/spec/geodesic-circle.test.ts
+++ b/spec/geodesic-circle.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import L from "leaflet";
+import * as L from "leaflet";
 import { GeodesicOptions } from "../src/geodesic-core"
 import { GeodesicCircleClass } from "../src/geodesic-circle";
 import { expect } from "chai";

--- a/spec/geodesic-core.test.ts
+++ b/spec/geodesic-core.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import L from "leaflet";
+import * as L from "leaflet";
 import { GeodesicCore, WGS84Vector, GeodesicOptions } from "../src/geodesic-core";
 import { expect } from "chai";
 

--- a/spec/geodesic-geom-circle.test.ts
+++ b/spec/geodesic-geom-circle.test.ts
@@ -4,7 +4,7 @@
 import { GeodesicGeometry } from "../src/geodesic-geom";
 import { expect } from "chai";
 
-import L from "leaflet";
+import * as L from "leaflet";
 
 import "jest";
 

--- a/spec/geodesic-geom.test.ts
+++ b/spec/geodesic-geom.test.ts
@@ -4,7 +4,7 @@
 import { GeodesicGeometry } from "../src/geodesic-geom";
 import { expect } from "chai";
 
-import L from "leaflet";
+import * as L from "leaflet";
 
 import "jest";
 

--- a/spec/geodesic-line.test.ts
+++ b/spec/geodesic-line.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import L from "leaflet";
+import * as L from "leaflet";
 import { GeodesicOptions } from "../src/geodesic-core"
 import { GeodesicLine } from "../src/geodesic-line";
 import { readFileSync } from "fs";

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import L from "leaflet";
+import * as L from "leaflet";
 import "../src/index";
 
 import { expect } from "chai";

--- a/spec/test-toolbox.ts
+++ b/spec/test-toolbox.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import * as L from "leaflet";
 import { expect } from "chai";
 
 import "jest";

--- a/spec/types-helper.test.ts
+++ b/spec/types-helper.test.ts
@@ -6,7 +6,7 @@ import { instanceOfLatLngExpression, latlngExpressiontoLatLng, latlngExpressionA
 import { expect } from "chai";
 
 import "jest";
-import L from "leaflet";
+import * as L from "leaflet";
 
 import { eps } from "./test-toolbox";
 

--- a/src/geodesic-circle.ts
+++ b/src/geodesic-circle.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import * as L from "leaflet";
 import { GeodesicGeometry, Statistics } from "./geodesic-geom"
 import { GeodesicOptions } from "./geodesic-core"
 import { latlngExpressiontoLatLng } from "./types-helper";

--- a/src/geodesic-core.ts
+++ b/src/geodesic-core.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import * as L from "leaflet";
 
 export interface GeodesicOptions extends L.PolylineOptions {
     wrap?: boolean,

--- a/src/geodesic-geom.ts
+++ b/src/geodesic-geom.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import * as L from "leaflet";
 import { GeodesicCore, GeodesicOptions, WGS84Vector } from "./geodesic-core"
 
 /** detailled information of the current geometry */

--- a/src/geodesic-line.ts
+++ b/src/geodesic-line.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import * as L from "leaflet";
 import { GeodesicOptions } from "./geodesic-core"
 import { GeodesicGeometry, Statistics } from "./geodesic-geom";
 import { latlngExpressiontoLatLng, latlngExpressionArraytoLatLngArray } from "../src/types-helper";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,24 @@
-import L from "leaflet";
+import "leaflet";
 import { GeodesicLine } from './geodesic-line';
 import { GeodesicCircleClass } from './geodesic-circle';
 
 declare module "leaflet" {
-        type Geodesic = GeodesicLine;
-        let Geodesic: typeof GeodesicLine;
-        let geodesic: (...args: ConstructorParameters<typeof GeodesicLine>) => GeodesicLine;
+    type Geodesic = GeodesicLine;
+    let Geodesic: typeof GeodesicLine;
+    let geodesic: (...args: ConstructorParameters<typeof GeodesicLine>) => GeodesicLine;
 
-        type GeodesicCircle = GeodesicCircleClass;
-        let GeodesicCircle: typeof GeodesicCircleClass;
-        let geodesiccircle: (...args: ConstructorParameters<typeof GeodesicCircleClass>) => GeodesicCircleClass;
+    type GeodesicCircle = GeodesicCircleClass;
+    let GeodesicCircle: typeof GeodesicCircleClass;
+    let geodesiccircle: (...args: ConstructorParameters<typeof GeodesicCircleClass>) => GeodesicCircleClass;
 }
 
-L.Geodesic = GeodesicLine;
-L.geodesic = (...args: ConstructorParameters<typeof GeodesicLine>) => new GeodesicLine(...args);
+if (typeof window.L !== "undefined") {
+    window.L.Geodesic = GeodesicLine;
+    window.L.geodesic = (...args: ConstructorParameters<typeof GeodesicLine>) => new GeodesicLine(...args);
 
-L.GeodesicCircle = GeodesicCircleClass;
-L.geodesiccircle = (...args: ConstructorParameters<typeof GeodesicCircleClass>) => new GeodesicCircleClass(...args);
+    window.L.GeodesicCircle = GeodesicCircleClass;
+    window.L.geodesiccircle = (...args: ConstructorParameters<typeof GeodesicCircleClass>) => new GeodesicCircleClass(...args);
+}
 
 export * from './geodesic-line';
 export * from './geodesic-circle';

--- a/src/types-helper.ts
+++ b/src/types-helper.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import * as L from "leaflet";
 
 export function instanceOfLatLngLiteral(object: any): object is L.LatLngLiteral {
     return ((typeof object === "object")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
@@ -46,7 +46,7 @@
     "typeRoots": ["node_modules/@types"],     /* List of folders to include type definitions from. */
     "types": ["node"],                        /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "esModuleInterop": true,               /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */


### PR DESCRIPTION
Hi @henrythasler, after trying multiple solutions in my `leaflet-lasso`, I settled up with `rollup-plugin-dts` to bundle all types into one file. Since you based your TS code on my repo, and I finished exporting the types afterwards, here is a PR for you :)

TS compiler option `esModuleInterop` must be disabled for compatibility with dependents who can't enable this option, see https://github.com/zakjan/leaflet-lasso/issues/21

Fixes #62 